### PR TITLE
Add set_register_bit service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
     diagnostic_updater
     std_srvs
     robotnik_msgs
-    std_msgs    
+    std_msgs
 )
 
 
@@ -32,6 +32,7 @@ catkin_package(
 include_directories(
 	include
 	/usr/include/modbus
+  /usr/local/include/modbus
 	${catkin_INCLUDE_DIRS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ catkin_package(
 include_directories(
 	include
 	/usr/include/modbus
-  /usr/local/include/modbus
 	${catkin_INCLUDE_DIRS}
 )
 

--- a/src/robotnik_modbus_io_node.cpp
+++ b/src/robotnik_modbus_io_node.cpp
@@ -37,8 +37,6 @@
 #include <cerrno>
 #include <cstdio>
 #include <csignal>
-#include <cmath>
-#include <bitset>
 
 #include <iostream>
 #include <typeinfo>

--- a/src/robotnik_modbus_io_node.cpp
+++ b/src/robotnik_modbus_io_node.cpp
@@ -634,11 +634,11 @@ public:
   {
     if (value)
     {
-      return reg & ~(1 << bit);
+      return reg | (1 << bit);
     }
     else
     {
-      return reg | (1 << bit);
+      return reg & ~(1 << bit);
     }
   }
 


### PR DESCRIPTION
This service allows to change the value of a single bit for a specific register. 

Due to the limitations of the PLCs modbus implementations, we can't use Modbus function 22 (0x16) ([https://libmodbus.org/reference/modbus_mask_write_register/]). The PLC's Modbus client does not implement this functions, causing a communication error whenever we try to use it.

Our solution consists on reading the register value, modify the specified bit with the desired boolean value, and writing the new register value.